### PR TITLE
use-blocking-queue-by-default-for-arm

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -73,7 +73,9 @@ public abstract class Recycler<T> {
         // bursts.
         RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
 
-        BLOCKING_POOL = SystemPropertyUtil.getBoolean("io.netty.recycler.blocking", false);
+        String arch = PlatformDependent.normalizedArch();
+        boolean isArm = arch.equals("aarch_64") || arch.equals("arm_32");
+        BLOCKING_POOL = SystemPropertyUtil.getBoolean("io.netty.recycler.blocking", isArm);
 
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {


### PR DESCRIPTION
Motivation:

As we already know in #11972:
> The Recycler has been observed to produce infinite loops on ARM CPUs.
> It is not clear if this is caused by a JDK bug, a JCTools bug, or a Recycler bug.
> Having the ability to switch out the JCTools queue implementation will aid us in the investigation.

This bug also occurs on my ARM cluster. #11972 introduced a configuration property "io.netty.recycler.blocking" to workaround with the issue, it's works for me. 

It will be better if this 

Modification:

Set "io.netty.recycler.blocking" default value as true on ARM CPUs.

Result:

The infinite loops bug could be ruled out by default.
